### PR TITLE
[TASK] Introduce page level cache for translation mode

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,4 +16,5 @@ services:
   ITSC\LanguageModeSwitch\Middleware\Frontend\LanguageModeSwitch:
     public: true
     arguments:
+      - '@cache.pages'
       - '@querybuilder.pages'


### PR DESCRIPTION
This will speed up loading the translation mode, especially in installations that have a faster caching backend like redis or memcache.

The cache will become more relevant with the upcoming feature "automatic free mode" which needs to lookup content elements in the database.