### PR TITLE
[TASK] Hide field in page properties of default language

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -12,6 +12,7 @@ $additionalPagesColumns = [
         'exclude' => true,
         'label' => $ll . 'pages.l10n_mode',
         'description' => $ll . 'pages.l10n_mode.description',
+        'displayCond' => 'FIELD:l10n_parent:!=:0',
         'config' => [
             'type' => 'select',
             'renderType' => 'selectSingle',


### PR DESCRIPTION
Setting anything here has no effect and might be confusing because an
editor might assume that it will have an effect for all languages of this page.