### PR TITLE
[FEATURE] Add automatic mode

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -4,6 +4,14 @@ defined('TYPO3_MODE') or die();
 
 $ll = 'LLL:EXT:language_mode_switch/Resources/Private/Language/locallang_db.xlf:';
 
+$extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)
+    ->get('language_mode_switch');
+
+$defaultLabel = $ll . 'pages.l10n_mode.default';
+if ($extensionConfiguration['automaticMode']) {
+    $defaultLabel = $ll . 'pages.l10n_mode.automatic';
+}
+
 /**
  * Add extra fields to the pages record
  */
@@ -17,13 +25,13 @@ $additionalPagesColumns = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'items' => [
-                ['', ''],
+                [$defaultLabel, ''],
                 [$ll . 'pages.l10n_mode.strict', 'strict'],
                 [$ll . 'pages.l10n_mode.fallback', 'fallback'],
                 [$ll . 'pages.l10n_mode.free', 'free'],
-            ]
-        ]
-    ]
+            ],
+        ],
+    ],
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,6 +3,9 @@
     <file source-language="en" datatype="plaintext" original="messages" date="2021-09-12T14:00:00Z" product-name="language_mode_switch">
         <header/>
         <body>
+            <trans-unit id="ext_conf.automaticMode">
+                <source>Enable Automatic Mode: When the page module says "connected", then fallback mode will be used. If it says "free", free mode will be used.</source>
+            </trans-unit>
             <trans-unit id="pages.l10n_mode">
                 <source>Language Fallback Type</source>
             </trans-unit>
@@ -10,6 +13,12 @@
                 <source>This will change system wide language handling for this page in this language only.
                     This value will set the legacy sys_language_mode handling for this page only, no inheritance.
                     Use with care!</source>
+            </trans-unit>
+            <trans-unit id="pages.l10n_mode.automatic">
+                <source>Automatic: Uses "Fallback" if the page module says Connected Mode and "Free" if the page module says Free Mode.</source>
+            </trans-unit>
+            <trans-unit id="pages.l10n_mode.default">
+                <source>Default: Uses the global default setting for this language</source>
             </trans-unit>
             <trans-unit id="pages.l10n_mode.strict">
                 <source>Strict: Show only translated content, based on overlays</source>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=Features; type=boolean; label=LLL:EXT:language_mode_switch/Resources/Private/Language/locallang_db.xlf:ext_conf.automaticMode
+automaticMode = 0


### PR DESCRIPTION
Automatic mode can be enabled in the extension configuration. It is off by default.
If automatic mode is enabled the frontend will behave according to what the page module displays for each language.
When it says "Connected Mode", then "fallback" will be used in the frontend.
When it says "Free Mode", then "free" will be used in the frontend.

With automatic mode enabled, you can still override the behaviour in the translated page properties.