### PR TITLE
[TASK] Stop supplying explicit service arguments to middleware

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,16 +5,5 @@ services:
   ITSC\LanguageModeSwitch\:
     resource: '../Classes/*'
 
-  querybuilder.pages:
-    class: 'TYPO3\CMS\Core\Database\Query\QueryBuilder'
-    factory:
-      - '@TYPO3\CMS\Core\Database\ConnectionPool'
-      - 'getQueryBuilderForTable'
-    arguments:
-      - 'pages'
-
   ITSC\LanguageModeSwitch\Middleware\Frontend\LanguageModeSwitch:
     public: true
-    arguments:
-      - '@cache.pages'
-      - '@querybuilder.pages'


### PR DESCRIPTION
This avoids setting up a database connection when the middleware is instanciated